### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Autocomplete text field. It works like Safari (iOS) or Chrome (iOS) search / add
 
 ![screenShot](https://github.com/Antol/APAutocompleteTextField/raw/master/Screen%20Shot.png)
 
-###How to install
+### How to install
 
 Install using CocoaPods.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
